### PR TITLE
Revert to the mhart/kinesalite branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 RUN apt-get -y install nodejs
 RUN apt-get -y install build-essential
 RUN apt-get -y install git
-RUN npm install -g git+https://github.com/virtyx-technologies/kinesalite.git
+RUN npm install -g git+https://github.com/mhart/kinesalite.git
 
 EXPOSE 4567
 


### PR DESCRIPTION
mhart has now merged in the deduplication fix, and added AT_TIMESTAMP support to kinesalite. It would be good to fold this into the published docker image.